### PR TITLE
Add support for using the Date header in StringToSign

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -425,6 +425,25 @@ typedef enum
 
 
 /**
+ * S3STSDate represents which header(s) contain(s) the date in the StringToSign.
+ *
+ * Some S3 servers require the Date header to be populated, even if
+ * x-amz-date contains the definitive timestamp for a request.
+ *
+ * S3STSAmzOnly indicates that only the x-amz-date header should be used.
+ * S3STSDateOnly indicates that only the Date header should be used.
+ * S3STSAmzAndDate indicates that both x-amz-date and the Date header
+ * should be used. 
+ **/
+typedef enum
+{
+    S3STSAmzOnly                     = 0,
+    S3STSDateOnly                    = 1,
+    S3STSAmzAndDate                  = 2
+} S3STSDate;
+
+
+/**
  * S3GranteeType defines the type of Grantee used in an S3 ACL Grant.
  * Amazon Customer By Email - identifies the Grantee using their Amazon S3
  *     account email address
@@ -711,6 +730,11 @@ typedef struct S3BucketContext
      *  The Amazon Security Token used to generate Temporary Security Credentials
      **/
     const char *securityToken;
+
+    /**
+     *  The date header style to use in the StringToSign
+     **/
+    S3STSDate stsDate;
 } S3BucketContext;
 
 
@@ -1732,6 +1756,7 @@ S3Status S3_generate_authenticated_query_string
  * Lists all S3 buckets belonging to the access key id.
  *
  * @param protocol gives the protocol to use for this request
+ * @param stsDate gives the date header to be used in the StringToSign
  * @param accessKeyId gives the Amazon Access Key ID for which to list owned
  *        buckets
  * @param secretAccessKey gives the Amazon Secret Access Key for which to list
@@ -1748,7 +1773,7 @@ S3Status S3_generate_authenticated_query_string
  * @param callbackData will be passed in as the callbackData parameter to
  *        all callbacks for this request
  **/
-void S3_list_service(S3Protocol protocol, const char *accessKeyId,
+void S3_list_service(S3Protocol protocol, S3STSDate stsDate, const char *accessKeyId,
                      const char *secretAccessKey, const char *securityToken,
                      const char *hostName, S3RequestContext *requestContext,
                      const S3ListServiceHandler *handler,
@@ -1764,6 +1789,7 @@ void S3_list_service(S3Protocol protocol, const char *accessKeyId,
  *
  * @param protocol gives the protocol to use for this request
  * @param uriStyle gives the URI style to use for this request
+ * @param stsDate gives the date header to be used in the StringToSign
  * @param accessKeyId gives the Amazon Access Key ID for which to list owned
  *        buckets
  * @param secretAccessKey gives the Amazon Secret Access Key for which to list
@@ -1791,6 +1817,7 @@ void S3_list_service(S3Protocol protocol, const char *accessKeyId,
  *        all callbacks for this request
  **/
 void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
+                    S3STSDate stsDate,
                     const char *accessKeyId, const char *secretAccessKey,
                     const char *securityToken, const char *hostName, 
                     const char *bucketName, int locationConstraintReturnSize,
@@ -1803,6 +1830,7 @@ void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
  * Creates a new bucket.
  *
  * @param protocol gives the protocol to use for this request
+ * @param stsDate gives the date header to be used in the StringToSign
  * @param accessKeyId gives the Amazon Access Key ID for which to list owned
  *        buckets
  * @param secretAccessKey gives the Amazon Secret Access Key for which to list
@@ -1823,7 +1851,8 @@ void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
  * @param callbackData will be passed in as the callbackData parameter to
  *        all callbacks for this request
  **/
-void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
+void S3_create_bucket(S3Protocol protocol, S3STSDate stsDate,
+                      const char *accessKeyId,
                       const char *secretAccessKey, const char *securityToken,
                       const char *hostName, const char *bucketName,
                       S3CannedAcl cannedAcl, const char *locationConstraint,
@@ -1837,6 +1866,7 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
  *
  * @param protocol gives the protocol to use for this request
  * @param uriStyle gives the URI style to use for this request
+ * @param stsDate gives the date header to be used in the StringToSign
  * @param accessKeyId gives the Amazon Access Key ID for which to list owned
  *        buckets
  * @param secretAccessKey gives the Amazon Secret Access Key for which to list
@@ -1855,6 +1885,7 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
  *        all callbacks for this request
  **/
 void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
+                      S3STSDate stsDate,
                       const char *accessKeyId, const char *secretAccessKey,
                       const char *securityToken, const char *hostName, 
                       const char *bucketName, S3RequestContext *requestContext,

--- a/src/acl.c
+++ b/src/acl.c
@@ -128,7 +128,8 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         "acl",                                        // subResource
@@ -327,7 +328,8 @@ void S3_set_acl(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         "acl",                                        // subResource

--- a/src/bucket.c
+++ b/src/bucket.c
@@ -104,7 +104,7 @@ static void testBucketCompleteCallback(S3Status requestStatus,
     free(tbData);
 }
 
-void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
+void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle, S3STSDate stsDate,
                     const char *accessKeyId, const char *secretAccessKey,
                     const char *securityToken, const char *hostName,
                     const char *bucketName, int locationConstraintReturnSize,
@@ -140,7 +140,8 @@ void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
           uriStyle,                                   // uriStyle
           accessKeyId,                                // accessKeyId
           secretAccessKey,                            // secretAccessKey
-          securityToken },                            // securityToken
+          securityToken,                              // securityToken
+          stsDate },                                  // stsDate
         0,                                            // key
         0,                                            // queryParams
         "location",                                   // subResource
@@ -224,7 +225,7 @@ static void createBucketCompleteCallback(S3Status requestStatus,
 }
 
 
-void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
+void S3_create_bucket(S3Protocol protocol, S3STSDate stsDate, const char *accessKeyId,
                       const char *secretAccessKey, const char *securityToken,
                       const char *hostName, const char *bucketName,
                       S3CannedAcl cannedAcl, const char *locationConstraint,
@@ -280,7 +281,8 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
           S3UriStylePath,                             // uriStyle
           accessKeyId,                                // accessKeyId
           secretAccessKey,                            // secretAccessKey
-          securityToken },                            // securityToken
+          securityToken,                              // securityToken
+          stsDate },                                  // stsDate
         0,                                            // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -336,7 +338,7 @@ static void deleteBucketCompleteCallback(S3Status requestStatus,
 }
 
 
-void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
+void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle, S3STSDate stsDate,
                       const char *accessKeyId, const char *secretAccessKey,
                       const char *securityToken, const char *hostName, 
                       const char *bucketName, S3RequestContext *requestContext,
@@ -364,7 +366,8 @@ void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
           uriStyle,                                   // uriStyle
           accessKeyId,                                // accessKeyId
           secretAccessKey,                            // secretAccessKey
-          securityToken },                            // securityToken
+          securityToken,                              // securityToken
+          stsDate },                                  // stsDate
         0,                                            // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -724,7 +727,8 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         0,                                            // key
         queryParams[0] ? queryParams : 0,             // queryParams
         0,                                            // subResource

--- a/src/multipart.c
+++ b/src/multipart.c
@@ -116,8 +116,9 @@ void S3_initiate_multipart(S3BucketContext *bucketContext, const char *key,
           bucketContext->protocol,                    // protocol
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             //secretAccessKey    
-          bucketContext->securityToken },             // secretToken
+          bucketContext->secretAccessKey,             // secretAccessKey    
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         "uploads",                                    // subResource
@@ -155,8 +156,9 @@ void S3_abort_multipart_upload(S3BucketContext *bucketContext, const char *key,
           bucketContext->protocol,                    // protocol
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             //secretAccessKey    
-          bucketContext->securityToken },             // secretToken
+          bucketContext->secretAccessKey,             // secretAccessKey    
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         subResource,                                  // subResource
@@ -200,8 +202,9 @@ void S3_upload_part(S3BucketContext *bucketContext, const char *key,
           bucketContext->protocol,                    // protocol
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             //secretAccessKey    
-          bucketContext->securityToken },             // secretToken
+          bucketContext->secretAccessKey,             // secretAccessKey    
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         subResource,                                  // subResource
@@ -337,8 +340,9 @@ void S3_complete_multipart_upload(S3BucketContext *bucketContext,
           bucketContext->protocol,                    // protocol
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             //secretAccessKey    
-          bucketContext->securityToken },             // secretToken
+          bucketContext->secretAccessKey,             // secretAccessKey    
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         subResource,                                  // subResource
@@ -930,7 +934,8 @@ void S3_list_multipart_uploads(S3BucketContext *bucketContext,
               bucketContext->uriStyle,               // uriStyle
               bucketContext->accessKeyId,            // accessKeyId
               bucketContext->secretAccessKey,        // secretAccessKey
-              bucketContext->securityToken },        // securityToken
+              bucketContext->securityToken,          // securityToken
+              bucketContext->stsDate },              // stsDate
             0,                                       // key
             queryParams[0] ? queryParams : 0,        // queryParams
             "uploads",                               // subResource
@@ -1051,7 +1056,8 @@ void S3_list_parts(S3BucketContext *bucketContext, const char *key,
               bucketContext->uriStyle,               // uriStyle
               bucketContext->accessKeyId,            // accessKeyId
               bucketContext->secretAccessKey,        // secretAccessKey
-              bucketContext->securityToken },        // securityToken
+              bucketContext->securityToken,          // securityToken
+              bucketContext->stsDate },              // stsDate
             key,                                     // key
             queryParams[0] ? queryParams : 0,        // queryParams
             subResource,                             // subResource

--- a/src/object.c
+++ b/src/object.c
@@ -48,7 +48,8 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -208,7 +209,8 @@ void S3_copy_object(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         destinationKey ? destinationKey : key,        // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -249,7 +251,8 @@ void S3_get_object(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -288,7 +291,8 @@ void S3_head_object(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -327,7 +331,8 @@ void S3_delete_object(const S3BucketContext *bucketContext, const char *key,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource

--- a/src/request.c
+++ b/src/request.c
@@ -776,11 +776,6 @@ static S3Status compose_auth_header(const RequestParams *params,
 
     signbuf_append("%s", values->canonicalizedResource);
 
-// DEBUG CODE
-    fprintf(stdout,"---String to sign:---\n");
-    fprintf(stdout,"%s",(unsigned char *) signbuf);
-    fprintf(stdout,"\n---\n\n");
-// /DEBUG CODE
     // Generate an HMAC-SHA-1 of the signbuf
     unsigned char hmac[20];
 

--- a/src/s3.c
+++ b/src/s3.c
@@ -64,7 +64,7 @@ static S3Protocol protocolG = S3ProtocolHTTPS;
 static S3UriStyle uriStyleG = S3UriStylePath;
 static int retriesG = 5;
 static int verifyPeerG = 0;
-static S3STSDate = S3STSAmzOnly;
+static S3STSDate stsDateG = S3STSAmzOnly;
 
 
 // Environment variables, saved as globals ----------------------------------
@@ -3589,7 +3589,7 @@ int main(int argc, char **argv)
     // Parse args
     while (1) {
         int idx = 0;
-        int c = getopt_long(argc, argv, "vfhusr:", longOptionsG, &idx);
+        int c = getopt_long(argc, argv, "dvfhusr:", longOptionsG, &idx);
 
         if (c == -1) {
             // End of options

--- a/src/service.c
+++ b/src/service.c
@@ -130,7 +130,7 @@ static void completeCallback(S3Status requestStatus,
 }
 
 
-void S3_list_service(S3Protocol protocol, const char *accessKeyId,
+void S3_list_service(S3Protocol protocol, S3STSDate stsDate, const char *accessKeyId,
                      const char *secretAccessKey, const char *securityToken,
                      const char *hostName, S3RequestContext *requestContext,
                      const S3ListServiceHandler *handler, void *callbackData)
@@ -167,7 +167,8 @@ void S3_list_service(S3Protocol protocol, const char *accessKeyId,
           S3UriStylePath,                             // uriStyle
           accessKeyId,                                // accessKeyId
           secretAccessKey,                            // secretAccessKey
-          securityToken },                            // securityToken
+          securityToken,                              // securityToken
+          stsDate },                                  // stsDate
         0,                                            // key
         0,                                            // queryParams
         0,                                            // subResource

--- a/src/service_access_logging.c
+++ b/src/service_access_logging.c
@@ -329,7 +329,8 @@ void S3_get_server_access_logging(const S3BucketContext *bucketContext,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         0,                                            // key
         0,                                            // queryParams
         "logging",                                    // subResource
@@ -534,7 +535,8 @@ void S3_set_server_access_logging(const S3BucketContext *bucketContext,
           bucketContext->uriStyle,                    // uriStyle
           bucketContext->accessKeyId,                 // accessKeyId
           bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken },             // securityToken
+          bucketContext->securityToken,               // securityToken
+          bucketContext->stsDate },                   // stsDate
         0,                                            // key
         0,                                            // queryParams
         "logging",                                    // subResource


### PR DESCRIPTION
This is for compatibility with some non-Amazon S3-based services that use the Date header in the StringToSign, which is signed with the user's key and used for authentication.

See http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html "Time Stamp Requirement" and "Example Delete" for additional explanation.
