### PR TITLE
Extract ETag for upload-part-copy

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -104,7 +104,8 @@ static S3Status copyObjectXmlCallback(const char *elementPath,
         if (!strcmp(elementPath, "CopyObjectResult/LastModified")) {
             string_buffer_append(coData->lastModified, data, dataLen, fit);
         }
-        else if (!strcmp(elementPath, "CopyObjectResult/ETag")) {
+        else if (!strcmp(elementPath, "CopyObjectResult/ETag")
+              || !strcmp(elementPath, "CopyPartResult/ETag")) {
             if (coData->eTagReturnSize && coData->eTagReturn) {
                 coData->eTagReturnLen +=
                     snprintf(&(coData->eTagReturn[coData->eTagReturnLen]),


### PR DESCRIPTION
This PR fixes issue when using irods_resource_plugin_s3 with S3 provided by Openstack Swift.
The error was seen with MPU file when "moving" it into trash.

How to reproduce issue on irods:

```
$ dd if=/dev/zero of=bigfile bs=1M count=129
$ iput -R compResc big
$ irm big
remote addresses: 127.0.0.1 ERROR: rmUtil: rm error for /tempZone/home/alice/big, status = -702000 status = -702000 S3_PUT_ERROR
```

The upload-part-copy network dump:
```
PUT /test/irods/Vault/trash/home/alice/big?partNumber=1&uploadId=ZjMwMzk4ZjktZGNiNy00YjhjLTk3ZGQtNDkxMjdlZWM0NTgz HTTP/1.1
Host: 10.21.78.1:5000
User-Agent: Mozilla/4.0 (Compatible; s3; libs3 2.0; Linux x86_64)
Accept: */*
Range: bytes=0-67108863
Authorization: AWS demo:demo:cEfgp+OFwUNsLz7IBmD0JgYjDl0=
x-amz-date: Wed, 02 Oct 2019 16:09:47 GMT
x-amz-copy-source: /test/irods/Vault/home/alice/big
x-amz-copy-source-range: bytes=0-67108864
x-amz-metadata-directive: REPLACE
Expect: 100-continue

HTTP/1.1 200 OK
Content-Length: 220
x-amz-id-2: tx186c3dba12d84fa38fc5f-005d94cbcb
Last-Modified: Wed, 02 Oct 2019 16:09:47 GMT
x-amz-request-id: tx186c3dba12d84fa38fc5f-005d94cbcb
x-amz-version-id: 1570032581479313
Content-Type: application/xml
X-Trans-Id: tx186c3dba12d84fa38fc5f-005d94cbcb
X-Openstack-Request-Id: tx186c3dba12d84fa38fc5f-005d94cbcb
Date: Wed, 02 Oct 2019 16:09:48 GMT

<?xml version='1.0' encoding='UTF-8'?>
<CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-10-02T16:09:47.000Z</LastModified><ETag>"279f6c15a48c009464bece2b1bb75a70"</ETag></CopyPartResult>
```

The complete-multipart-upload operation:
```
POST /test/irods/Vault/trash/home/alice/big?uploadId=ZjMwMzk4ZjktZGNiNy00YjhjLTk3ZGQtNDkxMjdlZWM0NTgz HTTP/1.1
Host: 10.21.78.1:5000
User-Agent: Mozilla/4.0 (Compatible; s3; libs3 2.0; Linux x86_64)
Accept: */*
Content-Length: 159
Authorization: AWS demo:demo:Nz7hBBdlrC58ohLCVL/qxeZJuVs=
x-amz-date: Wed, 02 Oct 2019 16:09:48 GMT
Expect: 100-continue

<CompleteMultipartUpload>
<Part><PartNumber>1</PartNumber><ETag></ETag></Part>
<Part><PartNumber>2</PartNumber><ETag></ETag></Part>
</CompleteMultipartUpload>

HTTP/1.1 500 Internal Server Error
x-amz-id-2: txfe16f6f0e4e74282b820b-005d94cbcc
Connection: Close
x-amz-request-id: txfe16f6f0e4e74282b820b-005d94cbcc
Content-Type: application/xml
X-Trans-Id: txfe16f6f0e4e74282b820b-005d94cbcc
X-Openstack-Request-Id: txfe16f6f0e4e74282b820b-005d94cbcc
Date: Wed, 02 Oct 2019 16:09:48 GMT
Transfer-Encoding: chunked

<?xml version='1.0' encoding='UTF-8'?>
<Error>
  <Code>InternalError</Code>
  <Message>We encountered an internal error. Please try again.</Message>
  <RequestId>txfe16f6f0e4e74282b820b-005d94cbcc</RequestId>
  <Reason>object of type 'NoneType' has no len()</Reason>
</Error>
```

On swift gateway, it triggers error at https://github.com/openstack/swift/blob/master/swift/common/middleware/s3api/controllers/multi_upload.py#L612